### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.5.3",
   "description": "A Prometheus metrics registry implemented in TypeScript",
   "main": "lib/index.js",
-  "module": "lib/index.js",
   "typings": "lib/index.d.ts",
   "private": false,
   "files": [
@@ -20,7 +19,7 @@
   "scripts": {
     "build": "rm -rf lib && npm run build:js && npm run build:types && npm run build:bundle",
     "build:js": "esbuild src/*.ts --platform=neutral --format=cjs --sourcemap=inline --outdir=lib",
-    "build:bundle": "esbuild src/index.ts --bundle --minify --outfile=lib/browser/promjs-plus.min,js",
+    "build:bundle": "esbuild src/index.ts --bundle --minify --outfile=lib/browser/promjs-plus.min.js",
     "build:types": "tsc --emitDeclarationOnly",
     "format": "eslint . --fix",
     "lint": "eslint .",


### PR DESCRIPTION
The generated lib/index.js file is NOT an ESM module, it contains:

```js
module.exports = __toCommonJS(src_exports);
```

This causes errors like "`module` is not defined" when importing as ESM.

Remove the `module:` field from package.json to fix it.